### PR TITLE
Update GitHub Actions to use Node.js 22.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,17 +14,14 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    # Node.js version - using latest LTS
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+    - uses: actions/checkout@v4
+    - name: Use Node.js 22.x
+      uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 22.x
         cache: 'npm'
     - run: npm ci
     - run: npm run build --if-present


### PR DESCRIPTION
- Remove matrix build strategy for simpler configuration
- Update to Node.js 22.x (latest LTS)
- Update actions/checkout and actions/setup-node to v4